### PR TITLE
Change z-index to 9 instead of 99

### DIFF
--- a/src/lib/HistogramSlider.vue
+++ b/src/lib/HistogramSlider.vue
@@ -348,7 +348,7 @@ export default {
   left: 0;
   cursor: default;
   white-space: nowrap;
-  z-index: 99;
+  z-index: 9;
 }
 
 .irs-grid {


### PR DESCRIPTION
For the following css selectors: 

.irs-from,
.irs-to,
.irs-single

the z-index is set to 99, which seems a mistake compared to the z-index of the other selectors z-index. Found this while trying to have my modal overlaying the vue3-histogram-slider, but the .irs-from, .irs-to, and .irs-single keps sneaking through by modal. 
